### PR TITLE
Update imports to match latest LiteX.

### DIFF
--- a/netv2.py
+++ b/netv2.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python3
 
-import sys
 import os
-import math
 import argparse
 
-from migen import *
+from migen import ClockDomain, Module, If, Signal
 from migen.genlib.misc import WaitTimer
 
 from litex.build import tools
 
-from litex.boards.platforms import netv2
+from litex_boards.platforms import netv2
 
-from litex.soc.interconnect.csr import *
-from litex.soc.integration.soc_sdram import *
-from litex.soc.integration.builder import *
-from litex.soc.integration.export import *
+from litex.soc.integration.soc_sdram import SoCSDRAM
+from litex.soc.interconnect.csr import CSR, AutoCSR
+from litex.soc.integration.builder import Builder
+from litex.soc.integration.export import get_csr_header, get_soc_header, get_mem_header
+
 
 from litex.soc.cores.clock import S7PLL, S7IDELAYCTRL
 from litex.soc.cores.dna import DNA
@@ -27,10 +26,8 @@ from litex.soc.cores.spi_flash import S7SPIFlash
 from litedram.modules import K4B2G1646F
 from litedram.phy import s7ddrphy
 from litedram.frontend.dma import LiteDRAMDMAReader
-from litedram.frontend.dma import LiteDRAMDMAWriter
 
 from liteeth.phy.rmii import LiteEthPHYRMII
-from liteeth.core.mac import LiteEthMAC
 from liteeth.core import LiteEthUDPIPCore
 from liteeth.frontend.etherbone import LiteEthEtherbone
 


### PR DESCRIPTION
Even with these changes, I'm still getting a build failure with the following error that I wasn't able to immediately debug:
```
Traceback (most recent call last):
  File "./netv2.py", line 311, in <module>
    main()
  File "./netv2.py", line 296, in main
    soc      = NeTV2(platform)
  File "./netv2.py", line 124, in __init__
    self.submodules.flash = S7SPIFlash(platform.request("flash"), sys_clk_freq, 25e6)
  File "/usr/local/google/home/keithrothman/cat_x/litex/litex/litex/build/generic_platform.py", line 309, in request
    return self.constraint_manager.request(*args, **kwargs)
  File "/usr/local/google/home/keithrothman/cat_x/litex/litex/litex/build/generic_platform.py", line 190, in request
    resource = _lookup(self.available, name, number, loose)
  File "/usr/local/google/home/keithrothman/cat_x/litex/litex/litex/build/generic_platform.py", line 97, in _lookup
    raise ConstraintError("Resource not found: {}:{}".format(name, number))
litex.build.generic_platform.ConstraintError: Resource not found: flash:None
```

Replication instructions (on Linux):
```
mkdir netv2_test
cd netv2_test/
python3 -mvenv env 
source env/bin/activate
mkdir litex
pushd litex
wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
chmod +x litex_setup.py
./litex_setup.py init install
popd
git clone -b update_to_latest_litex git@github.com:litghost/netv2.git
cd netv2
./netv2.py --build
```